### PR TITLE
feat: Add version subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ build-local:
 	@for target in $(TARGETS); do                                                      \
 	  go build -v -o $(OUTPUT_DIR)/$${target}                                          \
 	    -ldflags "-s -w -X $(ROOT)/pkg/version.VERSION=$(VERSION)                      \
-		  -X $(ROOT)/pkg/version.COMMIT=$(GITSHA)                                      \
+	      -X $(ROOT)/pkg/version.COMMIT=$(GITSHA)                                      \
 	      -X $(ROOT)/pkg/version.REPOROOT=$(ROOT)"                                     \
 	    $(CMD_DIR)/$${target};                                                         \
 	done

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ BUILD_DIR := ./build
 
 # Current version of the project.
 VERSION ?= $(shell git describe --tags --always --dirty)
+GITSHA ?= $(shell git rev-parse --short HEAD)
 
 # Available cpus for compiling, please refer to https://github.com/caicloud/engineering/issues/8186#issuecomment-518656946 for more information.
 CPUS ?= $(shell /bin/bash hack/read_cpus_available.sh)
@@ -117,6 +118,7 @@ build-local:
 	@for target in $(TARGETS); do                                                      \
 	  go build -v -o $(OUTPUT_DIR)/$${target}                                          \
 	    -ldflags "-s -w -X $(ROOT)/pkg/version.VERSION=$(VERSION)                      \
+		  -X $(ROOT)/pkg/version.COMMIT=$(GITSHA)                                      \
 	      -X $(ROOT)/pkg/version.REPOROOT=$(ROOT)"                                     \
 	    $(CMD_DIR)/$${target};                                                         \
 	done

--- a/cmd/ormb-storage-initializer/cmd/version.go
+++ b/cmd/ormb-storage-initializer/cmd/version.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// pullCmd represents the pull command
+// versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show the version information",

--- a/cmd/ormb-storage-initializer/cmd/version.go
+++ b/cmd/ormb-storage-initializer/cmd/version.go
@@ -1,0 +1,36 @@
+/*
+Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"github.com/caicloud/ormb/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+// pullCmd represents the pull command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show the version information",
+	Long:  ``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		version.PrintVersion()
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/cmd/ormb/cmd/version.go
+++ b/cmd/ormb/cmd/version.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// pullCmd represents the pull command
+// versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show the version information",

--- a/cmd/ormb/cmd/version.go
+++ b/cmd/ormb/cmd/version.go
@@ -1,0 +1,36 @@
+/*
+Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"github.com/caicloud/ormb/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+// pullCmd represents the pull command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show the version information",
+	Long:  ``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		version.PrintVersion()
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -4,6 +4,11 @@
 
 package version
 
+import (
+	"fmt"
+	"runtime"
+)
+
 // Following values should be substituted with a real value during build.
 var (
 	// VERSION is the app-global version string.
@@ -15,3 +20,21 @@ var (
 	// REPOROOT is the app-global repository path string.
 	REPOROOT = "UNKNOWN"
 )
+
+// PrintVersion prints versions from the array returned by Info().
+func PrintVersion() {
+	for _, i := range Info() {
+		fmt.Printf("%v\n", i)
+	}
+}
+
+// Info returns an array of various service versions
+func Info() []string {
+	return []string{
+		fmt.Sprintf("Version: %s", VERSION),
+		fmt.Sprintf("Git SHA: %s", COMMIT),
+		fmt.Sprintf("Repo Root: %s", REPOROOT),
+		fmt.Sprintf("Go Version: %s", runtime.Version()),
+		fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
Signed-off-by: Ce Gao <gaoce@caicloud.io>

<!--  Thanks for sending a pull request! See below for tips! -->

**What this PR does / why we need it**:

Add version command for ormb and ormb-storage-initializer

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #

Reference to #
<!-- 填在 Fixes，PR 合并就会关 issue。填在 Reference to 会关联 issue，不会联动关闭。-->

**Special notes for your reviewer**:

/cc @your-reviewer

<!-- Please answer the following questions during the code freeze, and delete this line.
**Code freeze questions**

1. What causes this PR to not be merged before code freeze?
2. Why this PR is absolutely necessary for this version? Paste a screenshot of smoke testing docs if you could.
3. What's the effects after merging it?
4. Is there anyway we can skip this to not affect the overall process?
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```

<!--  Thanks for sending a pull request! Here are some tips:

1. https://github.com/caicloud/engineering/blob/master/guidelines/review_conventions.md      <-- what is the review process looks like
2. https://github.com/caicloud/engineering/blob/master/guidelines/git_commit_conventions.md  <-- how to structure your git commit
3. https://github.com/caicloud/engineering/blob/master/guidelines/caicloud_bot.md            <-- how to work with caicloud bot

Other tips:

If this is your first contribution, read our Getting Started guide https://github.com/caicloud/engineering/blob/master/guidelines/README.md
-->
